### PR TITLE
Fix typo in values public url variable

### DIFF
--- a/examples/helm/charts/prosody/templates/ingress.yaml
+++ b/examples/helm/charts/prosody/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "prosody.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := index .Values.service.ports "bosh-insecure" -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}

--- a/examples/helm/charts/prosody/templates/tests/test-connection.yaml
+++ b/examples/helm/charts/prosody/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "prosody.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "prosody.fullname" . }}:{{ index .Values.service.ports "bosh-insecure" }}']
   restartPolicy: Never

--- a/examples/helm/templates/_helpers.tpl
+++ b/examples/helm/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Create the name of the service account to use
 
 {{- define "jitsi-meet.publicURL" -}}
 {{- if .Values.publicURL }}
-{{ .Values.pulicURL }}
+{{- .Values.publicURL -}}
 {{- else -}}
 {{- if .Values.web.ingress.tls -}}https://{{- else -}}http://{{- end -}}
 {{- if .Values.web.ingress.tls -}}

--- a/examples/helm/values.yaml
+++ b/examples/helm/values.yaml
@@ -11,6 +11,7 @@ fullnameOverride: ""
 
 enableAuth: false
 enableGuests: true
+publicURL: ""
 
 tz: Europe/Amsterdam
 


### PR DESCRIPTION
- Fix typo
- Add sample value placeholder for `publicURL`
- Added default prosody web port when testing the connection

Associated error on apply:

> error validating data: unknown object type "nil" in ConfigMap.data.PUBLIC_URL